### PR TITLE
wrap header and related static function in conditional comment

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_54_2.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_2.rb
@@ -112,9 +112,9 @@ else
 
     contents.insert(207, comment_start)
     contents.insert(231, comment_end)
-  end
 
-  file = File.open(filepath, 'w') do |f|
-    f.puts(contents)
+    file = File.open(filepath, 'w') do |f|
+      f.puts(contents)
+    end
   end
 end

--- a/lib/cocoapods-fix-react-native/versions/0_54_4.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_4.rb
@@ -127,8 +127,27 @@ if has_dev_support
   edit_pod_file websocket, websocket_old_code, websocket_new_code
 else
   # There's a link in the DevSettings to dev-only import
-  dev_settings = 'React/Modules/RCTDevSettings.mm'
-  dev_settings_old_code = '#import "RCTPackagerClient.h"'
-  dev_settings_new_code = '//#import //"RCTPackagerClient.h"'
-  edit_pod_file dev_settings, dev_settings_old_code, dev_settings_new_code
+  filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
+  contents = []
+  file = File.open(filepath, 'r')
+  found = false
+  file.each_line do |line|
+    contents << line
+  end
+  file.close
+
+  comment_start = '#if ENABLE_PACKAGER_CONNECTION'
+  comment_end = '#endif'
+
+  if contents[22].rstrip != comment_start
+    contents.insert(22, comment_start)
+    contents.insert(24, comment_end)
+
+    contents.insert(207, comment_start)
+    contents.insert(231, comment_end)
+
+    file = File.open(filepath, 'w') do |f|
+      f.puts(contents)
+    end
+  end
 end


### PR DESCRIPTION
since `RCTPackagerClient.h` is commented out, `RCTPackagerClientResponder` is no longer available. But if I understand the code here correctly, the header will be available when the packager connection is enabled, so this should work in both cases.