### PR TITLE
CocoaPods + Frameworks:  Added missing subspec hints into the CocoaPods output

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_54_4.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_4.rb
@@ -83,12 +83,12 @@ def has_pods_project_source_file(source_filename)
 end
 
 # Detect dependent source file required for building when the given source file is present
-def has_pods_project_source_dependency(source_filename, dependent_source_filename)
-  return has_pods_project_source_file(source_filename) && has_pods_project_source_file(dependent_source_filename)
+def meets_pods_project_source_dependency(source_filename, dependent_source_filename)
+  has_pods_project_source_file(source_filename) ? has_pods_project_source_file(dependent_source_filename) : true
 end
 
 def detect_missing_subspec_dependency(subspec_name, source_filename, dependent_source_filename)
-  unless has_pods_project_source_dependency(source_filename, dependent_source_filename)
+  unless meets_pods_project_source_dependency(source_filename, dependent_source_filename)
     puts "[!] #{subspec_name} subspec may be required given your current dependencies"
   end
 end
@@ -100,6 +100,9 @@ def detect_missing_subspecs
   # When the React pod is generated it must include all the required source, and see umbrella deps.
   detect_missing_subspec_dependency('RCTNetwork', 'RCTBlobManager.mm', 'RCTNetworking.mm')
   detect_missing_subspec_dependency('CxxBridge', 'RCTJavaScriptLoader.mm', 'RCTCxxBridge.mm')
+
+  # RCTText itself shouldn't require DevSupport, but it depends on Core -> RCTDevSettings -> RCTPackagerClient
+  detect_missing_subspec_dependency('DevSupport', 'RCTDevSettings.mm', 'RCTPackagerClient.m')
 end
 
 fix_unused_yoga_headers

--- a/lib/cocoapods-fix-react-native/versions/0_54_4.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_4.rb
@@ -79,10 +79,7 @@ end
 # Detect source file dependency in the generated Pods.xcodeproj workspace sub-project
 def has_pods_project_source_file(source_filename)
   pods_project = 'Pods/Pods.xcodeproj/project.pbxproj'
-  if File.foreach(pods_project).grep(/#{source_filename}/).any?
-    return true
-  end
-  return false
+  File.open(pods_project).grep(/#{source_filename}/).any?
 end
 
 def detect_missing_subspecs


### PR DESCRIPTION
This adds hints into the CocoaPods output that you should add additional React subspecs, if we detect a frameworks environment and source code dependencies that can be resolved in the Podfile.  No more hints means you should be able to compile and link.

**Example Output**:

```
Patching React Native 0.54.4
[!] RCTNetwork subspec may be required given your current dependencies
```

This might be an interim approach, as ultimately the React pod could be dynamically constructed to have what it's missing (like CocoaPods already does) based on these detections.

### Background

Ultimately the React pod will need to find it's dependent code:
*  in other pods via framework umbrella headers
*  as source files in it's own target

In getting the first compile through with use_frameworks and only ['DevSupport'] as a React pod subspec, as @orta predicted they were resistant ;)  You hit jshelpers, then folly, then boost ...

### Other Approaches
* Submit changes to the React.podspec, to the react-native project
* Prompt the user to have their Podfile automatically updated
* zero-config style automatically add the React pod into the Podfile with these dependencies, if they add 'this' pod