### PR TITLE
Update the 4.3 validator to only error when a dep has RN in it's dep tree, instead of any time

### DIFF
--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -7,8 +7,10 @@ Pod::HooksManager.register('cocoapods-fix-react-native', :post_install) do |cont
   all_pods_targets = context.pods_project.targets
   all_pods_targets.each do |t|
     deployment_target = t.build_configurations.first.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
-    if deployment_target == '4.3'
-      raise 'You have a Pod who has a deployment target of 4.3.' + 
+    has_react_dep =  t.dependencies.find { |dep| dep.name == "React" }
+
+    if has_react_dep && deployment_target == '4.3'
+      raise 'You have a Pod which has a deployment target of 4.3, and a dependency on React.' + 
             "\nIn order for React Native to compile you need to give the Podspec for #{t.name} a version like `s.platform = :ios, '9.0'`.\n"
     end
   end


### PR DESCRIPTION
The check in #7 was too broad, now it should be tighter