### PR TITLE
Unconditionally fix DevSettings' reference to PackagerClient

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_54_2-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_2-post.rb
@@ -93,29 +93,29 @@ if has_dev_support
   websocket_old_code = 'import <fishhook/fishhook.h>'
   websocket_new_code = 'import <React/fishhook.h>'
   edit_pod_file websocket, websocket_old_code, websocket_new_code
-else
-  # There's a link in the DevSettings to dev-only import
-  filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
-  contents = []
-  file = File.open(filepath, 'r')
-  found = false
-  file.each_line do |line|
-    contents << line
-  end
-  file.close
+end
 
-  comment_start = '#if ENABLE_PACKAGER_CONNECTION'
-  comment_end = '#endif'
+# There's a link in the DevSettings to dev-only import
+filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
+contents = []
+file = File.open(filepath, 'r')
+found = false
+file.each_line do |line|
+  contents << line
+end
+file.close
 
-  if contents[22].rstrip != comment_start
-    contents.insert(22, comment_start)
-    contents.insert(24, comment_end)
+comment_start = '#if ENABLE_PACKAGER_CONNECTION'
+comment_end = '#endif'
 
-    contents.insert(207, comment_start)
-    contents.insert(231, comment_end)
+if contents[22].rstrip != comment_start
+  contents.insert(22, comment_start)
+  contents.insert(24, comment_end)
 
-    file = File.open(filepath, 'w') do |f|
-      f.puts(contents)
-    end
+  contents.insert(207, comment_start)
+  contents.insert(231, comment_end)
+
+  file = File.open(filepath, 'w') do |f|
+    f.puts(contents)
   end
 end

--- a/lib/cocoapods-fix-react-native/versions/0_54_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_4-post.rb
@@ -134,31 +134,31 @@ if has_dev_support
   websocket_old_code = 'import <fishhook/fishhook.h>'
   websocket_new_code = 'import <React/fishhook.h>'
   patch_pod_file websocket, websocket_old_code, websocket_new_code
-else
-  # There's a link in the DevSettings to dev-only import
-  filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
-  contents = []
-  file = File.open(filepath, 'r')
-  found = false
-  file.each_line do |line|
-    contents << line
-  end
-  file.close
+end
 
-  comment_start = '#if ENABLE_PACKAGER_CONNECTION'
-  comment_end = '#endif'
+# There's a link in the DevSettings to dev-only import
+filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
+contents = []
+file = File.open(filepath, 'r')
+found = false
+file.each_line do |line|
+  contents << line
+end
+file.close
 
-  if contents[22].rstrip != comment_start
-    Pod::UI.message "Patching #{filepath}", '- '
+comment_start = '#if ENABLE_PACKAGER_CONNECTION'
+comment_end = '#endif'
 
-    contents.insert(22, comment_start)
-    contents.insert(24, comment_end)
+if contents[22].rstrip != comment_start
+  Pod::UI.message "Patching #{filepath}", '- '
 
-    contents.insert(207, comment_start)
-    contents.insert(231, comment_end)
+  contents.insert(22, comment_start)
+  contents.insert(24, comment_end)
 
-    file = File.open(filepath, 'w') do |f|
-      f.puts(contents)
-    end
+  contents.insert(207, comment_start)
+  contents.insert(231, comment_end)
+
+  file = File.open(filepath, 'w') do |f|
+    f.puts(contents)
   end
 end

--- a/lib/cocoapods-fix-react-native/versions/0_55_3-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_55_3-post.rb
@@ -136,30 +136,30 @@ if has_dev_support
   websocket_old_code = 'import <fishhook/fishhook.h>'
   websocket_new_code = 'import <React/fishhook.h>'
   patch_pod_file websocket, websocket_old_code, websocket_new_code
-else
-  # There's a link in the DevSettings to dev-only import
-  filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
-  contents = []
-  file = File.open(filepath, 'r')
-  found = false
-  file.each_line do |line|
-    contents << line
-  end
-  file.close
+end
 
-  comment_start = '#if ENABLE_PACKAGER_CONNECTION'
-  comment_end = '#endif'
+# There's a link in the DevSettings to dev-only import
+filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
+contents = []
+file = File.open(filepath, 'r')
+found = false
+file.each_line do |line|
+  contents << line
+end
+file.close
 
-  if contents[20].include? 'RCTPackagerClient.h'
-    Pod::UI.message "Patching #{filepath}", '- '
-    contents.insert(20, comment_start)
-    contents.insert(22, comment_end)
+comment_start = '#if ENABLE_PACKAGER_CONNECTION'
+comment_end = '#endif'
 
-    contents.insert(205, comment_start)
-    contents.insert(229, comment_end)
+if contents[20].include? 'RCTPackagerClient.h'
+  Pod::UI.message "Patching #{filepath}", '- '
+  contents.insert(20, comment_start)
+  contents.insert(22, comment_end)
 
-    file = File.open(filepath, 'w') do |f|
-      f.puts(contents)
-    end
+  contents.insert(205, comment_start)
+  contents.insert(229, comment_end)
+
+  file = File.open(filepath, 'w') do |f|
+    f.puts(contents)
   end
 end

--- a/lib/cocoapods-fix-react-native/versions/0_55_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_55_4-post.rb
@@ -112,30 +112,30 @@ if has_dev_support
   websocket_old_code = 'import <fishhook/fishhook.h>'
   websocket_new_code = 'import <React/fishhook.h>'
   patch_pod_file websocket, websocket_old_code, websocket_new_code
-else
-  # There's a link in the DevSettings to dev-only import
-  filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
-  contents = []
-  file = File.open(filepath, 'r')
-  found = false
-  file.each_line do |line|
-    contents << line
-  end
-  file.close
+end
 
-  comment_start = '#if ENABLE_PACKAGER_CONNECTION'
-  comment_end = '#endif'
+# There's a link in the DevSettings to dev-only import
+filepath = "#{$root}/React/Modules/RCTDevSettings.mm"
+contents = []
+file = File.open(filepath, 'r')
+found = false
+file.each_line do |line|
+  contents << line
+end
+file.close
 
-  if contents[20].include? 'RCTPackagerClient.h'
-    Pod::UI.message "Patching #{filepath}", '- '
-    contents.insert(20, comment_start)
-    contents.insert(22, comment_end)
+comment_start = '#if ENABLE_PACKAGER_CONNECTION'
+comment_end = '#endif'
 
-    contents.insert(205, comment_start)
-    contents.insert(229, comment_end)
+if contents[20].include? 'RCTPackagerClient.h'
+  Pod::UI.message "Patching #{filepath}", '- '
+  contents.insert(20, comment_start)
+  contents.insert(22, comment_end)
 
-    file = File.open(filepath, 'w') do |f|
-      f.puts(contents)
-    end
+  contents.insert(205, comment_start)
+  contents.insert(229, comment_end)
+
+  file = File.open(filepath, 'w') do |f|
+    f.puts(contents)
   end
 end


### PR DESCRIPTION
The websocket files whose existence is being used as a guard here always seem to exist in `node_modules`?

This patch allows for a successful build using the react subspecs `['Core', 'CxxBridge', 'RCTText', 'RCTNetwork', 'RCTAnimation']` which otherwise fails due to `RCTDevSettings.mm`'s attempted inclusion of `RCTPackagerClient.h`.