### PR TITLE
Ability to set a custom React Native root directory via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ you can in your `Podfile`. This hook will first look at what version of React
 Native is installed, and will then run a corresponding scripts to make changes
 to the environment.
 
+## Custom React Native Root Directory
+
+To set a custom React Native root directory for dev an environment variable `COCOAPODS_FIX_REACT_NATIVE_DEV_ROOT` may be set.  Example:
+
+    # Some shell script that sets up environment variables
+    export COCOAPODS_FIX_REACT_NATIVE_DEV_ROOT="../my_react_project_directory/node_modules/react-native"
+
 ## Contributing Back
 
 You'll note that this repo has issues disabled, I'm not going to make the time

--- a/lib/cocoapods-fix-react-native/helpers/root_helper.rb
+++ b/lib/cocoapods-fix-react-native/helpers/root_helper.rb
@@ -1,0 +1,32 @@
+# Notes:
+#
+#  - All file paths should be relative to the React repo, rather than the Pods dir, or node_modules
+#  - An enviroment variable of `COCOAPODS_FIX_REACT_NATIVE_DEV_ROOT` will override the defaults for dev.
+#
+#  - Returns the root directory to use for React Native
+
+def get_root
+  # Are you using :path based Pods?
+  dev_pods_react = !File.directory?('Pods/React/React')
+
+  # Check for whether we're in a project that uses relative paths
+  same_repo_node_modules = File.directory?('node_modules/react-native')
+  previous_repo_node_modules = File.directory?('../node_modules/react-native')
+
+  # Find out where the files could be rooted
+  $root = 'Pods/React'
+
+  if dev_pods_react
+    # Use this as an override, if present and non empty string
+    $env_root = ENV["COCOAPODS_FIX_REACT_NATIVE_DEV_ROOT"]
+
+    if defined?($env_root) && ($env_root != nil) && ($env_root != '')
+      $root = $env_root
+    else
+      $root = 'node_modules/react-native' if same_repo_node_modules
+      $root = '../node_modules/react-native' if previous_repo_node_modules
+    end
+  end
+
+  return $root
+end

--- a/lib/cocoapods-fix-react-native/versions/0_53_3-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_53_3-post.rb
@@ -1,26 +1,10 @@
-require 'cocoapods'
+require 'cocoapods-fix-react-native/helpers/root_helper'
 
-# Notes:
-#
-#  - All file paths should be relative to the React repo, rather than the Pods dir, or node_modules
-#
-
-# Are you using :path based Pods?
-dev_pods_react = !File.directory?('Pods/React/React')
+# Obtain the React Native root directory
+$root = get_root
 
 # Detect CocoaPods + Frameworks
-$has_frameworks = File.exist?('Pods/Target Support Files/React/React-umbrella.h')
-
-# Check for whether we're in a project that uses relative paths
-same_repo_node_modules = File.directory?('node_modules/react-native')
-previous_repo_node_modules = File.directory?('../node_modules/react-native')
-
-# Find out where the files could be rooted
-$root = 'Pods/React'
-if dev_pods_react
-  $root = 'node_modules/react-native' if same_repo_node_modules
-  $root = '../node_modules/react-native' if previous_repo_node_modules
-end
+$has_frameworks = File.exists?'Pods/Target Support Files/React/React-umbrella.h'
 
 # TODO: move to be both file in pods and file in node_mods?
 def patch_pod_file(path, old_code, new_code)

--- a/lib/cocoapods-fix-react-native/versions/0_53_3-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_53_3-post.rb
@@ -1,3 +1,4 @@
+require 'cocoapods'
 require 'cocoapods-fix-react-native/helpers/root_helper'
 
 # Obtain the React Native root directory

--- a/lib/cocoapods-fix-react-native/versions/0_54_2-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_2-post.rb
@@ -1,21 +1,7 @@
-# Notes:
-#
-#  - All file paths should be relative to the React repo, rather than the Pods dir, or node_modules
-#
+require 'cocoapods-fix-react-native/helpers/root_helper'
 
-# Are you using :path based Pods?
-dev_pods_react = !File.directory?('Pods/React/React')
-
-# Check for whether
-same_repo_node_modules = File.directory?('node_modules/react-native')
-previous_repo_node_modules = File.directory?('../node_modules/react-native')
-
-# Find out where the files could be rooted
-$root = 'Pods/React'
-if dev_pods_react
-  $root = 'node_modules/react-native' if same_repo_node_modules
-  $root = '../node_modules/react-native' if previous_repo_node_modules
-end
+# Obtain the React Native root directory
+$root = get_root
 
 # TODO: move to be both file in pods and file in node_mods?
 def edit_pod_file(path, old_code, new_code)

--- a/lib/cocoapods-fix-react-native/versions/0_54_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_54_4-post.rb
@@ -1,26 +1,11 @@
 require 'cocoapods'
+require 'cocoapods-fix-react-native/helpers/root_helper'
 
-# Notes:
-#
-#  - All file paths should be relative to the React repo, rather than the Pods dir, or node_modules
-#
-
-# Are you using :path based Pods?
-dev_pods_react = !File.directory?('Pods/React/React')
+# Obtain the React Native root directory
+$root = get_root
 
 # Detect CocoaPods + Frameworks
 $has_frameworks = File.exists?'Pods/Target Support Files/React/React-umbrella.h'
-
-# Check for whether we're in a project that uses relative paths
-same_repo_node_modules = File.directory?('node_modules/react-native')
-previous_repo_node_modules = File.directory?('../node_modules/react-native')
-
-# Find out where the files could be rooted
-$root = 'Pods/React'
-if dev_pods_react
-  $root = 'node_modules/react-native' if same_repo_node_modules
-  $root = '../node_modules/react-native' if previous_repo_node_modules
-end
 
 # TODO: move to be both file in pods and file in node_mods?
 def patch_pod_file(path, old_code, new_code)

--- a/lib/cocoapods-fix-react-native/versions/0_55_3-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_55_3-post.rb
@@ -1,26 +1,11 @@
 require 'cocoapods'
+require 'cocoapods-fix-react-native/helpers/root_helper'
 
-# Notes:
-#
-#  - All file paths should be relative to the React repo, rather than the Pods dir, or node_modules
-#
-
-# Are you using :path based Pods?
-dev_pods_react = !File.directory?('Pods/React/React')
+# Obtain the React Native root directory
+$root = get_root
 
 # Detect CocoaPods + Frameworks
 $has_frameworks = File.exists?'Pods/Target Support Files/React/React-umbrella.h'
-
-# Check for whether we're in a project that uses relative paths
-same_repo_node_modules = File.directory?('node_modules/react-native')
-previous_repo_node_modules = File.directory?('../node_modules/react-native')
-
-# Find out where the files could be rooted
-$root = 'Pods/React'
-if dev_pods_react
-  $root = 'node_modules/react-native' if same_repo_node_modules
-  $root = '../node_modules/react-native' if previous_repo_node_modules
-end
 
 # TODO: move to be both file in pods and file in node_mods?
 def patch_pod_file(path, old_code, new_code)

--- a/lib/cocoapods-fix-react-native/versions/0_55_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_55_4-post.rb
@@ -1,26 +1,11 @@
 require 'cocoapods'
+require 'cocoapods-fix-react-native/helpers/root_helper'
 
-# Notes:
-#
-#  - All file paths should be relative to the React repo, rather than the Pods dir, or node_modules
-#
-
-# Are you using :path based Pods?
-dev_pods_react = !File.directory?('Pods/React/React')
+# Obtain the React Native root directory
+$root = get_root
 
 # Detect CocoaPods + Frameworks
 $has_frameworks = File.exists?'Pods/Target Support Files/React/React-umbrella.h'
-
-# Check for whether we're in a project that uses relative paths
-same_repo_node_modules = File.directory?('node_modules/react-native')
-previous_repo_node_modules = File.directory?('../node_modules/react-native')
-
-# Find out where the files could be rooted
-$root = 'Pods/React'
-if dev_pods_react
-  $root = 'node_modules/react-native' if same_repo_node_modules
-  $root = '../node_modules/react-native' if previous_repo_node_modules
-end
 
 # TODO: move to be both file in pods and file in node_mods?
 def patch_pod_file(path, old_code, new_code)


### PR DESCRIPTION
Title says it all.

If need be, I could un-refactor the `get_root` back into the version files.