### PR TITLE
Ignore a missing Podfile.lock

### DIFF
--- a/lib/cocoapods-fix-react-native/fix_with_context.rb
+++ b/lib/cocoapods-fix-react-native/fix_with_context.rb
@@ -35,8 +35,12 @@ class CocoaPodsFixReactNative
   def pre_fix_with_context(context)
     # Get the current version of React Native in your app
     locked_dependencies = Molinillo::DependencyGraph.new
-    context.lockfile.dependencies.each do |dependency|
-      locked_dependencies.add_vertex(dependency.name, dependency, true)
+    if context.lockfile
+      context.lockfile.dependencies.each do |dependency|
+        locked_dependencies.add_vertex(dependency.name, dependency, true)
+      end
+    else
+      Pod::UI.warn 'No Podfile.lock present. Continuing without locked dependencies.'
     end
 
     sources = context.podfile.sources.map do |source|


### PR DESCRIPTION
I'm part of a team which is integrating a React Native module into an existing iOS application which I don't own. For *reasons* the team looking after the app has decided to lock all of their dependencies in the Podfile and not use a Podfile.lock at all.

Currently, the pre_fix_with_context hook is expecting the Podfile.lock to exist, which while entirely reasonable unfortunately isn't true in my case.

I've modified the code to check the presence of the lockfile before attempting to iterate its dependencies. I've thrown a warning when it's not present; while not necessary I thought it was a nice FYI.