### PR TITLE
Fix "'React/fishhook.h' file not found" error in RCTReconnectingWebSocket.m (RN 0.55.4)

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_55_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_55_4-post.rb
@@ -94,7 +94,7 @@ has_dev_support = File.exist?(File.join($root, 'Libraries/WebSocket/RCTReconnect
 if has_dev_support
   # Move Fishhook to be based on RN's imports
   websocket = 'Libraries/WebSocket/RCTReconnectingWebSocket.m'
-  websocket_old_code = 'import <React/fishhook.h>'
+  websocket_old_code = 'import <fishhook/fishhook.h>'
   websocket_new_code = 'import "fishhook.h"'
   patch_pod_file websocket, websocket_old_code, websocket_new_code
 end


### PR DESCRIPTION
There has been a problem importing fishhook in multiple versions of react-native. This fixes works for react-native 0.55.4.

https://github.com/facebook/react-native/issues/16039