### PR TITLE
Support React Native 0.57.1 and 0.57.2

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_57_1-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_57_1-post.rb
@@ -1,0 +1,2 @@
+require_relative './0_57_0-post'
+

--- a/lib/cocoapods-fix-react-native/versions/0_57_2-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_57_2-post.rb
@@ -1,0 +1,2 @@
+require_relative './0_57_1-post'
+


### PR DESCRIPTION
Add support for RN [0.57.1](https://www.npmjs.com/package/react-native/v/0.57.1) and [0.57.2](https://www.npmjs.com/package/react-native/v/0.57.2). It looks like neither of those versions require additional fixes, so we simply apply 0.57.0 fix without any changes.