### PR TITLE
Support React Native 0.57.4

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_57_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_57_4-post.rb
@@ -1,0 +1,2 @@
+require_relative './0_57_3-post'
+


### PR DESCRIPTION
React Native 0.57.4 is out ([release](https://www.npmjs.com/package/react-native/v/0.57.4), [changelog](https://github.com/facebook/react-native/compare/v0.57.3...v0.57.4)).

PS. It looks a bit cumbersome to introduce those trivial changes and go through a `cocoapods-fix-react-native` release cycle for every patch release of RN. Will you accept a PR which introduces pre/post patches for a minor version of RN (like `0.57-post.rb`) and attempts to load them if there's no patch for the exact version?