### PR TITLE
Fix header search paths in RN 0.58

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_58_0-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_0-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_57_8-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_0-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_0-pre.rb
@@ -1,0 +1,48 @@
+require 'cocoapods'
+require 'cocoapods-fix-react-native/helpers/root_helper'
+
+# Obtain the React Native root directory
+$root = get_root
+
+# TODO: move to be both file in pods and file in node_mods?
+def patch_pod_file(path, old_code, new_code)
+  file = File.join($root, path)
+  unless File.exist?(file)
+    Pod::UI.warn "#{file} does not exist so was not patched.."
+    return
+  end
+  code = File.read(file)
+  if code.include?(old_code)
+    Pod::UI.message "Patching #{file}", '- '
+    FileUtils.chmod('+w', file)
+    File.write(file, code.sub(old_code, new_code))
+  end
+end
+
+# https://github.com/facebook/react-native/pull/23274
+react_podspec_file = 'React.podspec'
+react_podspec_old_code = '
+  s.subspec "jsiexecutor" do |ss|
+    ss.dependency             "React/cxxreact"
+    ss.dependency             "React/jsi"
+    ss.dependency             "Folly", folly_version
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "ReactCommon/jsiexecutor/jsireact/*.{cpp,h}"
+    ss.private_header_files = "ReactCommon/jsiexecutor/jsireact/*.h"
+    ss.header_dir           = "jsireact"
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
+  end
+'
+react_podspec_new_code = '
+s.subspec "jsiexecutor" do |ss|
+    ss.dependency             "React/cxxreact"
+    ss.dependency             "React/jsi"
+    ss.dependency             "Folly", folly_version
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "ReactCommon/jsiexecutor/jsireact/*.{cpp,h}"
+    ss.private_header_files = "ReactCommon/jsiexecutor/jsireact/*.h"
+    ss.header_dir           = "jsireact"
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\", \"$(PODS_TARGET_SRCROOT)/ReactCommon/jsiexecutor\"" }
+  end
+'
+patch_pod_file react_podspec_file, react_podspec_old_code, react_podspec_new_code

--- a/lib/cocoapods-fix-react-native/versions/0_58_1-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_1-post.rb
@@ -1,1 +1,1 @@
-require_relative './0_57_8-post'
+require_relative './0_58_0-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_1-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_1-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_0-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_58_2-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_2-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_1-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_2-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_2-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_1-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_58_3-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_3-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_2-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_3-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_3-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_2-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_58_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_4-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_3-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_4-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_4-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_3-pre'


### PR DESCRIPTION
This backports this fix facebook/react-native#23274 for those using CocoaPods with RN 0.58.x

It requires a pre-hook because it changes the `React.podspec`