### PR TITLE
add 0.58.5 and 0.58.6 pre/post

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_58_5-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_5-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_4-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_5-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_5-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_4-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_58_6-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_6-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_5-post'

--- a/lib/cocoapods-fix-react-native/versions/0_58_6-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_6-pre.rb
@@ -1,1 +1,31 @@
 require_relative './0_58_5-pre'
+
+# https://github.com/facebook/react-native/issues/23390
+react_podspec_file = 'React.podspec'
+react_podspec_old_code = '
+  s.subspec "cxxreact" do |ss|
+    ss.dependency             "React/jsinspector"
+    ss.dependency             "boost-for-react-native", "1.63.0"
+    ss.dependency             "Folly", folly_version
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "ReactCommon/cxxreact/*.{cpp,h}"
+    ss.exclude_files        = "ReactCommon/cxxreact/SampleCxxModule.*"
+    ss.private_header_files = "ReactCommon/cxxreact/*.h"
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Folly\"" }
+  end
+'
+react_podspec_new_code = '
+  s.subspec "cxxreact" do |ss|
+    ss.dependency             "React/jsinspector"
+    ss.dependency             "boost-for-react-native", "1.63.0"
+    ss.dependency             "Folly", folly_version
+    ss.dependency             "DoubleConversion", "1.1.6"
+    ss.dependency             "glog", "0.3.5"
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "ReactCommon/cxxreact/*.{cpp,h}"
+    ss.exclude_files        = "ReactCommon/cxxreact/SampleCxxModule.*"
+    ss.private_header_files = "ReactCommon/cxxreact/*.h"
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Folly\"" }
+  end
+'
+patch_pod_file react_podspec_file, react_podspec_old_code, react_podspec_new_code

--- a/lib/cocoapods-fix-react-native/versions/0_58_6-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_58_6-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_5-pre'


### PR DESCRIPTION
Propagates the pre/post hooks that already existed for 0.58.4 for 0.58.5 and 0.58.6.

Also fixes the dependency issue mentioned in facebook/react-native#23390.