### PR TITLE
Support React Native 0.59.x

### DIFF
--- a/lib/cocoapods-fix-react-native/versions/0_57_8-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_57_8-post.rb
@@ -1,2 +1,2 @@
-require_relative './0_57_5-post'
+require_relative './0_57_7-post'
 

--- a/lib/cocoapods-fix-react-native/versions/0_57_8-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_57_8-post.rb
@@ -1,0 +1,2 @@
+require_relative './0_57_5-post'
+

--- a/lib/cocoapods-fix-react-native/versions/0_59_0-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_0-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_6-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_0-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_0-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_58_6-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_1-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_1-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_0-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_1-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_1-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_0-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_10-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_10-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_9-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_10-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_10-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_9-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_2-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_2-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_1-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_2-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_2-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_1-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_3-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_3-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_2-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_3-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_3-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_2-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_4-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_4-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_3-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_4-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_4-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_3-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_5-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_5-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_4-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_5-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_5-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_4-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_6-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_6-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_5-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_6-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_6-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_5-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_7-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_7-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_6-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_7-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_7-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_6-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_8-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_8-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_7-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_8-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_8-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_7-pre'

--- a/lib/cocoapods-fix-react-native/versions/0_59_9-post.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_9-post.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_8-post'

--- a/lib/cocoapods-fix-react-native/versions/0_59_9-pre.rb
+++ b/lib/cocoapods-fix-react-native/versions/0_59_9-pre.rb
@@ -1,0 +1,1 @@
+require_relative './0_59_8-pre'


### PR DESCRIPTION
This PR provides support for React Native from version 0.59.0 up to 0.59.10.
There wasn't any specific patch to apply, so this PR only consists of files using require_relative.